### PR TITLE
Prevent a divide-by-zero bug in the pinch-to-zoom function

### DIFF
--- a/core/src/com/shatteredpixel/shatteredpixeldungeon/scenes/CellSelector.java
+++ b/core/src/com/shatteredpixel/shatteredpixeldungeon/scenes/CellSelector.java
@@ -224,7 +224,7 @@ public class CellSelector extends TouchArea<GameAction> {
 		if (pinching) {
 
 			float curSpan = PointF.distance( touch.current, another.current );
-			if (startSpan > 0){
+			if (startSpan != 0){
 				camera.zoom( GameMath.gate(
 					PixelScene.minZoom,
 					startZoom * curSpan / startSpan,


### PR DESCRIPTION
Ahoy there!

I'd only just started giving your pre-release a go-through when I ran into a bug that seemed big enough to warrant diverting my attention to it.

The bug is triggered when you press more than one of the mouse buttons at the same time while it's being moved. The gameplay portion of the screen then appears to turn black, and you can't use the mouse for input again until seemingly resetting the issue by issuing input form the keyboard. It turns out that the black screen is actually the screen being zoomed a number of levels higher than the logic tries to allow, which appears to happen because the two mouse buttons seem to be getting treated the same as two fingers on the screen, and if the mouse is being dragged, like two fingers on the screen being dragged, this looks like pinch to zoom. The difference however, is that instead of the `curSpan` and `startSpan` variables showing the difference in distance between the two inputs, they're both perpetually zero, which clearly causes problems with an equation that looks like `startZoom * curSpan / startSpan`. :) 

The funny thing is that this was caught because I was trying to test your re-release, but this bug seems like it's been there since the beginning, so on that note, I'm gonna copy-pasta this into a pull request for pixel-dungeon-gdx as well.

Cheers!
