### PR TITLE
Apply upstream improvement to access mappings in-game (commit:c67d4b5)

### DIFF
--- a/core/src/com/shatteredpixel/shatteredpixeldungeon/windows/WndKeymap.java
+++ b/core/src/com/shatteredpixel/shatteredpixeldungeon/windows/WndKeymap.java
@@ -39,8 +39,8 @@ public class WndKeymap extends Window {
 
 	public WndKeymap() {
 
-		int ww = Math.min( 160, Camera.main.width - 16 );
-		int wh = Camera.main.height - 24;
+		int ww = Math.min( 160, PixelScene.uiCamera.width - 16 );
+		int wh = PixelScene.uiCamera.height - 24;
 
 		resize( ww, wh );
 

--- a/core/src/com/shatteredpixel/shatteredpixeldungeon/windows/WndSettings.java
+++ b/core/src/com/shatteredpixel/shatteredpixeldungeon/windows/WndSettings.java
@@ -130,10 +130,11 @@ public class WndSettings extends Window {
 		btnSound.checked( ShatteredPixelDungeon.soundFx() );
 		add( btnSound );
 
+		Application.ApplicationType type = Gdx.app.getType();
+
 		Button lastBtn = btnSound;
 		if (!inGame) {
-			Application.ApplicationType type = Gdx.app.getType();
-			if (type == Application.ApplicationType.Android || type == Application.ApplicationType.iOS) {
+		/*	if (type == Application.ApplicationType.Android || type == Application.ApplicationType.iOS) {
 				RedButton btnOrientation = new RedButton(orientationText()) {
 					@Override
 					protected void onClick() {
@@ -144,16 +145,7 @@ public class WndSettings extends Window {
 				add(btnOrientation);
 
 				lastBtn = btnOrientation;
-			} else if (type == Application.ApplicationType.Desktop) {
-
-				RedButton btnKeymap = new RedButton( TXT_BINDINGS ) {
-					@Override
-					protected void onClick() {
-						parent.add(new WndKeymap());
-					}
-				};
-				btnKeymap.setRect(0, btnSound.bottom() + GAP, WIDTH, BTN_HEIGHT);
-				add(btnKeymap);
+			} else*/ if (type == Application.ApplicationType.Desktop) {
 
 				RedButton btnResolution = new RedButton(resolutionText()) {
 					@Override
@@ -162,7 +154,7 @@ public class WndSettings extends Window {
 					}
 				};
 				btnResolution.enable( ShatteredPixelDungeon.instance.getPlatformSupport().isFullscreenEnabled() );
-				btnResolution.setRect(0, btnKeymap.bottom() + GAP, WIDTH, BTN_HEIGHT);
+				btnResolution.setRect(0, btnSound.bottom() + GAP, WIDTH, BTN_HEIGHT);
 				add(btnResolution);
 
 				lastBtn = btnResolution;
@@ -183,6 +175,21 @@ public class WndSettings extends Window {
 			lastBtn = btnBrightness;
 			
 		}
+
+		if (type == Application.ApplicationType.Desktop) {
+
+			RedButton btnKeymap = new RedButton(TXT_BINDINGS) {
+				@Override
+				protected void onClick() {
+					parent.add(new WndKeymap());
+				}
+			};
+			btnKeymap.setRect(0, lastBtn.bottom() + GAP, WIDTH, BTN_HEIGHT);
+			add(btnKeymap);
+
+			lastBtn = btnKeymap;
+		}
+
 		resize(WIDTH, (int) lastBtn.bottom());
 	}
 	


### PR DESCRIPTION
Another merge of an [upstream commit](https://github.com/Arcnor/pixel-dungeon-gdx/commit/c67d4b5bff446c61ad875638f665724260e9b404) pushed by @watabou, this time enabling the ability to set key bindings from the settings menu in-game (as opposed to only at the title screen).
