### PR TITLE
Upstream NPE fix when clicking outside a window then back in (...

### DIFF
--- a/desktop/src/com/watabou/pd/desktop/DesktopInputProcessor.java
+++ b/desktop/src/com/watabou/pd/desktop/DesktopInputProcessor.java
@@ -118,8 +118,13 @@ public class DesktopInputProcessor extends PDInputProcessor {
 
 	@Override
 	public boolean touchUp(int screenX, int screenY, int pointer, int button) {
-		eventTouch.dispatch(pointers.remove(button).up());
-		return true;
+		Touch touch = pointers.remove(button);
+		if(touch != null) {
+			eventTouch.dispatch(touch.up());
+			return true;
+		}
+
+		return false;
 	}
 
 	@Override


### PR DESCRIPTION
merging upstream fix from [commit: e2a0995](https://github.com/Arcnor/pixel-dungeon-gdx/commit/e2a0995f2cfce4db2454626030dea04cd4862206)
